### PR TITLE
Added fix for issue when appending to ByteArray

### DIFF
--- a/printers@linux-man.org/extension.js
+++ b/printers@linux-man.org/extension.js
@@ -9,6 +9,7 @@ const Clutter = imports.gi.Clutter;
 const Util = imports.misc.util;
 const GLib = imports.gi.GLib;
 const Mainloop = imports.mainloop;
+const ByteArray = imports.byteArray;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
@@ -28,7 +29,7 @@ function spawn_async(args, callback) {
         let out_reader = new Gio.DataInputStream({base_stream: new Gio.UnixInputStream({fd: out_fd})});
         let [out, size] = out_reader.read_line(null);
         while (out !== null) {
-            strOUT += out + '\n';
+            strOUT += ByteArray.toString(out) + '\n';
             [out, size] = out_reader.read_line(null);
         }
     }


### PR DESCRIPTION
Fix for the this error message in Gnome Shell 3.30:
`Some code called array.toString() on a Uint8Array instance. Previously this would have interpreted the bytes of the array as a string, but that is nonstandard. In the future this will return the bytes as comma-separated digits. For the time being, the old behavior has been preserved, but please fix your code anyway to explicitly call ByteArray.toString(array).`